### PR TITLE
Refactored with better documentation and fix regression in 4968444

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,23 @@ A [Gulp](http://gulpjs.com) task for inlining images inside HTML. For example,
 becomes
 
 ```html
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEU...."/>
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEU..."/>
 ```
 
-This is mearly a wrapper for [inline-images](https://www.npmjs.com/package/inline-images) by [Max Ogden](http://github.com/maxogden).
+This is a wrapper for [inline-images](https://www.npmjs.com/package/inline-images) by [Max Ogden](http://github.com/maxogden).
 
 ### Usage
 
-```javascript
+```js
 var gulp = require('gulp');
-var inlineimg = require('gulp-inline-image');
+var inlineimg = require('gulp-inline-image-html');
 
 gulp.task('default', function () {
   gulp.src('src/**/*.html')
-    .pipe(inlineimg('src'))  // takes in the directory to use as the root when looking for images
+    .pipe(inlineimg('src')) // optionally pass in the base directory for looking for images
     .pipe(gulp.dest('dest/'));
 ```
+
+### License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-inline-image-html",
   "version": "0.2.2",
-  "description": "A gulp task for inlineing images in HTML",
+  "description": "A gulp task for inlining images in HTML",
   "main": "index.js",
   "scripts": {
     "test": "mocha test/test.js"
@@ -9,14 +9,14 @@
   "author": "Charles Julian Knight",
   "license": "MIT",
   "dependencies": {
-    "gulp-util": "^3.0.4",
+    "gulp-util": "^3.0.8",
     "inline-images": "^1.0.1",
     "through2": "^2.0.3"
   },
   "devDependencies": {
-    "chai": "^2.1.1",
-    "mocha": "^2.2.0",
-    "vinyl": "^0.4.6"
+    "chai": "^4.1.2",
+    "mocha": "^4.0.1",
+    "vinyl": "^2.1.0"
   },
   "keywords": [
     "gulpplugin",

--- a/test/test.js
+++ b/test/test.js
@@ -12,10 +12,11 @@ describe('gulp-inline-image', function(){
       var fakeFile = new File({
         contents: fs.readFileSync('test/fixtures/index.html')
       });
+
       var myInlineimg = inlineimg('test/fixtures');
+
       myInlineimg.write(fakeFile);
       myInlineimg.once('data', function(file) {
-
         expect(file.isBuffer()).to.be.true;
         expect(file.contents.toString('utf8')).not.to.contain('peppers.png');
         expect(file.contents.toString('utf8')).to.contain('src="data:');
@@ -25,4 +26,5 @@ describe('gulp-inline-image', function(){
     });
 
   });
+
 });


### PR DESCRIPTION
Stream transform function should not be checking for existence of file (4968444), and it's a chunk not a file.

This refactoring clarifies a number of things, including the optional base directory parameter and the relationship between this module, @maxogden's inline-images and the [through2](https://github.com/rvagg/through2) stream transform API.